### PR TITLE
Carthage support

### DIFF
--- a/LayerKitDiagnostics.xcodeproj/project.pbxproj
+++ b/LayerKitDiagnostics.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AA91B8161D74F6E600376BA0 /* LayerKitDiagnostics.h in Headers */ = {isa = PBXBuildFile; fileRef = AA91B8151D74F6E600376BA0 /* LayerKitDiagnostics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA91B81F1D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AA91B81D1D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.h */; };
+		AA91B81F1D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AA91B81D1D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA91B8201D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA91B81E1D74F7CF00376BA0 /* LYRDEmailDiagnosticsViewController.m */; };
 		AA91B8221D75FAC600376BA0 /* Pods_LayerKitDiagnostics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA91B8211D75FAC600376BA0 /* Pods_LayerKitDiagnostics.framework */; };
 		AA91B8281D764DE700376BA0 /* LayerKitDiagnostics.m in Sources */ = {isa = PBXBuildFile; fileRef = AA91B8271D764DE700376BA0 /* LayerKitDiagnostics.m */; };

--- a/LayerKitDiagnostics.xcodeproj/xcshareddata/xcschemes/LayerKitDiagnostics.xcscheme
+++ b/LayerKitDiagnostics.xcodeproj/xcshareddata/xcschemes/LayerKitDiagnostics.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA91B8111D74F6E600376BA0"
+               BuildableName = "LayerKitDiagnostics.framework"
+               BlueprintName = "LayerKitDiagnostics"
+               ReferencedContainer = "container:LayerKitDiagnostics.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA91B8111D74F6E600376BA0"
+            BuildableName = "LayerKitDiagnostics.framework"
+            BlueprintName = "LayerKitDiagnostics"
+            ReferencedContainer = "container:LayerKitDiagnostics.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA91B8111D74F6E600376BA0"
+            BuildableName = "LayerKitDiagnostics.framework"
+            BlueprintName = "LayerKitDiagnostics"
+            ReferencedContainer = "container:LayerKitDiagnostics.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This PR shares the scheme and updates the header so that LayerKit-Diagnostics can be used via Carthage.